### PR TITLE
Various fixes for compatibility with latest Julia

### DIFF
--- a/src/ArgParse.jl
+++ b/src/ArgParse.jl
@@ -1649,7 +1649,7 @@ function _parse_args_unhandled(args_list::Vector, settings::ArgParseSettings)
             continue
         elseif !arg_delim_found && beginswith(arg, "--")
             eq = search(arg, '=')
-            if i != 0
+            if eq != 0
                 opt_name = arg[3:eq-1]
                 arg_after_eq = arg[eq+1:end]
             else


### PR DESCRIPTION
- `contains(str, str)` -> `!isempty(search())` (maybe there is a better way?)
- `has(set, x)` -> `contains(set, x)`
- `keys()` now returns a `KeyIterator`, which breaks `_warn_extra_opts` because it
  wanted a `Vector{Symbol}`. Because the type parameter shouldn't be necessary
  and `KeyIterator` isn't exported from Base, I removed it.
