### PR TITLE
Add an option `dont_prefill_defaults` to ArgParseSettings

### DIFF
--- a/src/ArgParse.jl
+++ b/src/ArgParse.jl
@@ -232,6 +232,8 @@ This is the list of general settings currently available:
   ```
 
   The module also provides a function `ArgParse.debug_handler` (not exported) which will just rethrow the error.
+* `dont_prefill_defaults` (default = `false`): if `true`, the dictionary returned by [`parse_args`](@ref)
+  will only contain the entries corresponding to the options present in the given argument list.
 
 Here is a usage example:
 
@@ -284,6 +286,7 @@ type ArgParseSettings
     exc_handler::Function
     preformatted_description::Bool
     preformatted_epilog::Bool
+    dont_prefill_defaults::Bool
 
     function ArgParseSettings(;prog::AbstractString = Base.source_path() != nothing ? basename(Base.source_path()) : "",
                                description::AbstractString = "",
@@ -301,6 +304,7 @@ type ArgParseSettings
                                exc_handler::Function = default_handler,
                                preformatted_description::Bool=false,
                                preformatted_epilog::Bool=false,
+                               dont_prefill_defaults::Bool=false,
                                )
         fromfile_prefix_chars = check_prefix_chars(fromfile_prefix_chars)
         return new(
@@ -309,6 +313,7 @@ type ArgParseSettings
             suppress_warnings, allow_ambiguous_opts, commands_are_required,
             copy(std_groups), "", ArgParseTable(), exc_handler,
             preformatted_description, preformatted_epilog,
+            dont_prefill_defaults
             )
     end
 end
@@ -1886,9 +1891,11 @@ type ParserState
     out_dict::Dict{String,Any}
     function ParserState(args_list::Vector, settings::ArgParseSettings, truncated_shopts::Bool)
         out_dict = Dict{String,Any}()
-        for f in settings.args_table.fields
-            (f.action == :show_help || f.action == :show_version) && continue
-            out_dict[f.dest_name] = deepcopy(f.default)
+        if !settings.dont_prefill_defaults
+          for f in settings.args_table.fields
+              (f.action == :show_help || f.action == :show_version) && continue
+              out_dict[f.dest_name] = deepcopy(f.default)
+          end
         end
         new(deepcopy(args_list), false, nothing, nothing, false, 0, Set{AbstractString}(), nothing, truncated_shopts, out_dict)
     end


### PR DESCRIPTION
This option would be helpful in the following usage scenario. 

Suppose that, in addition to command-line arguments, the options can be supplied via function arguments, or a config file. One would want the command-line options to have the higher priority than that, so if an option is supplied from the command line, it overrides the config file value, or the value hardcoded in the program. This seems like a logical requirement, since the command-line options are the most "volatile" ones (they do not require re-compilation or changing some external file). 

This option helps to implement this kind of logic. Currently it is impossible to tell from the return value of `parse_args()` whether the value for an option was actually supplied by the user, or taken from the default value (and, therefore, should be looked for in a config file). 
