### PR TITLE
Update argparse_example4.jl

### DIFF
--- a/examples/argparse_example4.jl
+++ b/examples/argparse_example4.jl
@@ -13,13 +13,13 @@ function main(args)
     @add_arg_table s begin
         "--opt1"
             action = :append_const   # appends 'constant' to 'dest_name'
-            arg_type = ByteString    # the only utility of this is restricting the dest array type
+            arg_type = String
             constant = "O1"
             dest_name = "O_stack"    # this changes the destination
             help = "append O1"
         "--opt2"
             action = :append_const
-            arg_type = ByteString
+            arg_type = String
             constant = "O2"
             dest_name = "O_stack"    # same dest_name as opt1, different constant
             help = "append O2"
@@ -32,7 +32,7 @@ function main(args)
             nargs = '+'                         # eats up as many argument as found (at least 1)
             action = :append_arg                # argument chunks are appended when the option is
                                                 # called repeatedly
-            arg_type = ByteString
+            arg_type = String
             dest_name = "awk"
             range_tester = (x->x=="X"||x=="Y")  # each argument must be either "X" or "Y"
             metavar = "XY"


### PR DESCRIPTION
`ByteString` is deprecated, see for instance:
[https://github.com/JuliaLang/IJulia.jl/issues/443](https://github.com/JuliaLang/IJulia.jl/issues/443)
[https://github.com/JuliaLang/IJulia.jl/issues/445](https://github.com/JuliaLang/IJulia.jl/issues/445)