### PR TITLE
use @nospecialize to help with compile time

### DIFF
--- a/src/ArgParse.jl
+++ b/src/ArgParse.jl
@@ -33,7 +33,9 @@ export
 
 import Base: show, getindex, setindex!, haskey
 
-@nospecialize # use only declared type signatures, helps with compile time
+@static if VERSION >= v"0.7.0" 
+    @nospecialize # use only declared type signatures, helps with compile time
+end
 
 # auxiliary functions/constants
 found_a_bug() = error("you just found a bug in the ArgParse module, please report it.")

--- a/src/ArgParse.jl
+++ b/src/ArgParse.jl
@@ -33,6 +33,8 @@ export
 
 import Base: show, getindex, setindex!, haskey
 
+@nospecialize # use only declared type signatures, helps with compile time
+
 # auxiliary functions/constants
 found_a_bug() = error("you just found a bug in the ArgParse module, please report it.")
 const nbspc = '\u00a0'


### PR DESCRIPTION
This package taxes the compiler quite heavily which is unfortunate since it is likely quite important for an argument parsing library to be quite fast.

Taking a profile from the manual with the `@add_arg_table` call we get:

```
           856 ./none:0; (::getfield(ArgParse, Symbol("#kw##add_arg_field")))(::NamedTuple{(:default, :help, :arg_type),...
            826 /Users/osx/buildbot/slave/package_osx64/build/src/gf.c:1830; jl_fptr_trampoline
             615 /Users/osx/buildbot/slave/package_osx64/build/src/codegen.cpp:1410; jl_generate_fptr
              615 /Users/osx/buildbot/slave/package_osx64/build/src/codegen.cpp:1299; getAddressForFunction
               615 /Users/osx/buildbot/slave/package_osx64/build/src/jitlayers.cpp:863; jl_finalize_function
                615 /Users/osx/buildbot/slave/package_osx64/build/src/jitlayers.cpp:855; jl_add_to_ee
                 615 /Users/osx/buildbot/slave/package_osx64/build/src/jitlayers.cpp:608; addModule
                  611 ...build/usr/include/llvm/ExecutionEngine/Orc/IRCompileLayer.h:57; addModule
                   611 ...rs/osx/buildbot/slave/package_osx64/build/src/jitlayers.cpp:481; operator()
                    611 ...ia-1.0.app/Contents/Resources/julia/lib/julia/libLLVM.dylib:?; _ZN4llvm6legacy15PassManagerImpl3runERNS_6ModuleE
                     102 ...ia-1.0.app/Contents/Resources/julia/lib/julia/libLLVM.dylib:?; _ZN12_GLOBAL__N_113CGPassManager11runOnModuleERN4llvm6ModuleE

           724 ./none:0; (::getfield(ArgParse, Symbol("#kw##add_arg_field")))(::NamedTuple{(:help,),Tuple{String}}, ::typeof(ArgParse.add_arg_field), ::ArgParseSettings, ...
             645 /Users/osx/buildbot/slave/package_osx64/build/src/gf.c:1830; jl_fptr_trampoline
              550 /Users/osx/buildbot/slave/package_osx64/build/src/codegen.cpp:1410; jl_generate_fptr
               550 /Users/osx/buildbot/slave/package_osx64/build/src/codegen.cpp:1299; getAddressForFunction
                550 /Users/osx/buildbot/slave/package_osx64/build/src/jitlayers.cpp:863; jl_finalize_function
                 550 /Users/osx/buildbot/slave/package_osx64/build/src/jitlayers.cpp:855; jl_add_to_ee
                  549 /Users/osx/buildbot/slave/package_osx64/build/src/jitlayers.cpp:608; addModule
                   545 ...sx/buildbot/slave/package_osx64/build/usr/include/llvm/ExecutionEngine/Orc/IRCompileLayer.h:57; addModule
                    545 /Users/osx/buildbot/slave/package_osx64/build/src/jitlayers.cpp:481; operator()
                     545 /Applications/Julia-1.0.app/Contents/Resources/julia/lib/julia/libLLVM.dylib:?; _ZN4llvm6legacy15PassManagerImpl3runERNS_6ModuleEa

            452 ./none:0; (::getfield(ArgParse, Symbol("#kw##add_arg_field")))(::NamedTuple{(:help, :required),Tuple{String,Bool}}, ::typeof(ArgParse.add_arg_field), ::Arg...
             452 /Users/osx/buildbot/slave/package_osx64/build/src/gf.c:1830; jl_fptr_trampoline
              373 /Users/osx/buildbot/slave/package_osx64/build/src/codegen.cpp:1410; jl_generate_fptr
               373 /Users/osx/buildbot/slave/package_osx64/build/src/codegen.cpp:1299; getAddressForFunction
                373 /Users/osx/buildbot/slave/package_osx64/build/src/jitlayers.cpp:863; jl_finalize_function
                 373 /Users/osx/buildbot/slave/package_osx64/build/src/jitlayers.cpp:855; jl_add_to_ee
                  373 /Users/osx/buildbot/slave/package_osx64/build/src/jitlayers.cpp:608; addModule
                   370 ...sx/buildbot/slave/package_osx64/build/usr/include/llvm/ExecutionEngine/Orc/IRCompileLayer.h:57; addModule
                    370 /Users/osx/buildbot/slave/package_osx64/build/src/jitlayers.cpp:481; operator()
                     370 /Applications/Julia-1.0.app/Contents/Resources/julia/lib/julia/libLLVM.dylib:?; _ZN4llvm6legacy15PassManagerImpl3runERNS_6ModuleE
                      42  /Applications/Julia-1.0.app/Contents/Resources/julia/lib/julia/libLLVM.dylib:?; _ZN12_GLOBAL__N_113CGPassManager11runOnModuleERN4llvm6ModuleE
```

Here we have multiple invocations to LLVM specalizing and optimizing for the exact structure of the `NamedTuple` argument. This is not really needed, so this commit turns off specializing on untyped arguments.

The result is that before, the `@add_arg_table` call used to take

```
    3.861057 seconds (7.37 M allocations: 371.193 MiB, 4.70% gc time)
```

while it now takes

```
  2.106886 seconds (4.30 M allocations: 216.771 MiB, 5.46% gc time)
```

it is still slower than ideal but it is a bit on the way.