### PR TITLE
REPL mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See also the examples in the [examples directory](examples).
 ## Changes in release 1.0.0
 
 * Drop support for Julia versions v0.6/v0.7
+* Renamed function `import_settings` → `import_settings!`
 
 ## Changes in release 0.6.2
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See also the examples in the [examples directory](examples).
 ## Changes in release 1.0.0
 
 * Drop support for Julia versions v0.6/v0.7
+* Parsing does not exit julia by default when in interactive mode now
 * Renamed function `import_settings` → `import_settings!`
 
 ## Changes in release 0.6.2

--- a/src/ArgParse.jl
+++ b/src/ArgParse.jl
@@ -23,7 +23,7 @@ export
     @add_arg_table,
     add_arg_group,
     set_default_arg_group,
-    import_settings,
+    import_settings!,
     usage_string,
     parse_args
 

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -115,9 +115,9 @@ function usage_string(settings::ArgParseSettings)
 
     lc_len_limit = 24
 
-    cmd_lst = Any[]
-    pos_lst = Any[]
-    opt_lst = Any[]
+    cmd_lst = String[]
+    pos_lst = String[]
+    opt_lst = String[]
     for f in settings.args_table.fields
         if is_cmd(f)
             if !isempty(f.short_opt_name)

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -280,7 +280,7 @@ end
 
 show_help(settings::ArgParseSettings; kw...) = show_help(stdout, settings; kw...)
 
-function show_help(io::IO, settings::ArgParseSettings; exit_when_done = true)
+function show_help(io::IO, settings::ArgParseSettings; exit_when_done = !isinteractive())
 
     lc_len_limit = 24
     lc_left_indent = 2
@@ -369,7 +369,7 @@ end
 
 show_version(settings::ArgParseSettings; kw...) = show_version(stdout, settings; kw...)
 
-function show_version(io::IO, settings::ArgParseSettings; exit_when_done = true)
+function show_version(io::IO, settings::ArgParseSettings; exit_when_done = !isinteractive())
     println(io, settings.version)
     exit_when_done && exit(0)
     return
@@ -379,6 +379,10 @@ has_cmd(settings::ArgParseSettings) = any(is_cmd, settings.args_table.fields)
 
 # parse_args & friends
 function default_handler(settings::ArgParseSettings, err, err_code::Int = 1)
+    isinteractive() ? debug_handler(settings, err) : cmdline_handler(settings, err, err_code)
+end
+
+function cmdline_handler(settings::ArgParseSettings, err, err_code::Int = 1)
     println(stderr, err.text)
     println(stderr, usage_string(settings))
     exit(err_code)

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -280,8 +280,8 @@ ArgParseSettings(desc::AbstractString; kw...) = ArgParseSettings(; description =
 
 function show(io::IO, s::ArgParseSettings)
     println(io, "ArgParseSettings(")
-    for f in setdiff(fieldnames(ArgParseSettings), )
-        f ∈ [:args_groups, :args_table] && continue
+    for f in fieldnames(ArgParseSettings)
+        f ∈ (:args_groups, :args_table) && continue
         println(io, "  ", f, "=", getfield(s, f))
     end
     println(io, "  >> ", usage_string(s))

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -1153,7 +1153,7 @@ function set_default_arg_group(settings::ArgParseSettings, name::Union{AbstractS
     return
 end
 
-# import_settings & friends
+# import_settings! & friends
 function override_conflicts_with_commands(settings::ArgParseSettings, new_cmd::AbstractString)
     ids0 = Int[]
     for ia in 1:length(settings.args_table.fields)
@@ -1273,8 +1273,15 @@ function fix_commands_fields(fields::Vector{ArgParseField})
     end
 end
 
+# TODO: remove after minor version bump
+export import_settings
+function import_settings(args...; kw...)
+    @warn "`import_settings` is depreacted, use `import_settings!`"
+    import_settings!(args...; kw...)
+end
+
 """
-    import_settings(settings, other_settings [,args_only])
+    import_settings!(settings, other_settings [,args_only])
 
 Imports `other_settings` into `settings`, where both are [`ArgParseSettings`](@ref) objects. If
 `args_only` is `true` (this is the default), only the argument table will be imported; otherwise,
@@ -1296,9 +1303,9 @@ will not have any effect on `settings`.
 
 This function can be used at any time.
 """
-function import_settings(settings::ArgParseSettings,
-                         other::ArgParseSettings,
-                         args_only::Bool = true)
+function import_settings!(settings::ArgParseSettings,
+                          other::ArgParseSettings,
+                          args_only::Bool = true)
     check_settings_are_compatible(settings, other)
 
     fields = settings.args_table.fields
@@ -1359,7 +1366,7 @@ function import_settings(settings::ArgParseSettings,
         elseif !isempty(cmd_prog_hint)
             settings[subk].prog = "$(settings.prog) $cmd_prog_hint"
         end
-        import_settings(settings[subk], subs, args_only)
+        import_settings!(settings[subk], subs, args_only)
     end
     return settings
 end

--- a/test/argparse_test04.jl
+++ b/test/argparse_test04.jl
@@ -25,7 +25,7 @@ function ap_settings4()
                          error_on_conflict = false,  # do not error-out when trying to override an option
                          exc_handler = ArgParse.debug_handler)
 
-    import_settings(s, s0)       # now s has all of s0 arguments (except help/version)
+    import_settings!(s, s0)        # now s has all of s0 arguments (except help/version)
 
     @add_arg_table s begin
         "-o"                       # this will partially override s0's --parent-flag
@@ -69,7 +69,7 @@ function ap_settings4b()
     s = ArgParseSettings("Test 4 for ArgParse.jl",
                          version = "Version 1.0")
 
-    import_settings(s, s0, false)  # args_only set to false
+    import_settings!(s, s0, false)  # args_only set to false
 
     @add_arg_table s begin
         "-o"
@@ -172,7 +172,7 @@ end
 let s = ap_settings4_base()
 
     for s0 = [ap_settings4_conflict1(), ap_settings4_conflict2()]
-        @ee_test_throws import_settings(s, s0)
+        @ee_test_throws import_settings!(s, s0)
     end
 end
 

--- a/test/argparse_test05.jl
+++ b/test/argparse_test05.jl
@@ -259,7 +259,7 @@ function ap_settings5b()
             action = :store_true
     end
 
-    import_settings(s, s0)
+    import_settings!(s, s0)
 
     return s
 end


### PR DESCRIPTION
Default to not exiting julia from the REPL or IJulia.

Change defaults so that when `isinteractive()` is `true` we don't call `exit()`, and the package can be used e.g. from the REPL.

Fix #79
Fix #83

