### PR TITLE
Rename all mutating functions/macros by appending a `!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "ArgParse"
 uuid = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
-version = "1.0.0"
 author = ["Carlo Baldassi <carlobaldassi@gmail.com>"]
+version = "1.0.0"
 
 [deps]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 TextWrap = "b718987f-49a8-5099-9789-dcd902bef87d"
 
 [compat]

--- a/README.md
+++ b/README.md
@@ -32,10 +32,16 @@ See also the examples in the [examples directory](examples).
 ## Changes in release 1.0.0
 
 * Drop support for Julia versions v0.6/v0.7
+* Renamed a few functions and macros (old versions can be used but produced deprecation warnings):
+  + `@add_arg_table` → `@add_arg_table!`
+  + `add_arg_table` → `add_arg_table!`
+  + `add_arg_group` → `add_arg_group!`
+  + `set_default_arg_group` → `set_default_arg_group!`
+  + `import_settings` → `import_settings!`. The signature of this function has also changed:
+    `args_only` is now a keyword argument
 * Parsing does not exit julia by default when in interactive mode now
 * Added mutually-exclusive and/or required argument groups
 * Added command aliases
-* Renamed function `import_settings` → `import_settings!`
 
 ## Changes in release 0.6.2
 

--- a/docs/src/arg_table.md
+++ b/docs/src/arg_table.md
@@ -13,11 +13,11 @@ Each entry of the table consist of an argument name and a list of argument setti
 There are two very similar methods to populate a table:
 
 ```@docs
-@add_arg_table
+@add_arg_table!
 ```
 
 ```@docs
-add_arg_table
+add_arg_table!
 ```
 
 ## Argument names
@@ -139,7 +139,7 @@ using ArgParse
 * `store_arg` (non-flag): store the argument. This is the default unless `nargs` is `0`. Example:
 
   ```
-  julia> @add_arg_table(settings, "arg", action => :store_arg);
+  julia> @add_arg_table!(settings, "arg", action => :store_arg);
 
   julia> parse_args(["x"], settings)
   Dict{String,Any} with 1 entry:
@@ -149,7 +149,7 @@ using ArgParse
   The result is a vector if `nargs` is a non-zero number, or one of `'*'`, `'+'`, `'R'`:
 
   ```
-  julia> @add_arg_table(settings, "arg", action => :store_arg, nargs => 2);
+  julia> @add_arg_table!(settings, "arg", action => :store_arg, nargs => 2);
 
   julia> parse_args(["x", "y"], settings)
   Dict{String,Any} with 1 entry:
@@ -159,7 +159,7 @@ using ArgParse
 * `store_true` (flag): store `true` if given, otherwise `false`. Example:
 
   ```
-  julia> @add_arg_table(settings, "-v", action => :store_true);
+  julia> @add_arg_table!(settings, "-v", action => :store_true);
 
   julia> parse_args([], settings)
   Dict{String,Any} with 1 entry:
@@ -173,7 +173,7 @@ using ArgParse
 * `store_false` (flag): store `false` if given, otherwise `true`. Example:
 
   ```
-  julia> @add_arg_table(settings, "-v", action => :store_false);
+  julia> @add_arg_table!(settings, "-v", action => :store_false);
 
   julia> parse_args([], settings)
   Dict{String,Any} with 1 entry:
@@ -188,7 +188,7 @@ using ArgParse
   Example:
 
   ```
-  julia> @add_arg_table(settings, "-v", action => :store_const, constant => 1, default => 0);
+  julia> @add_arg_table!(settings, "-v", action => :store_const, constant => 1, default => 0);
 
   julia> parse_args([], settings)
   Dict{String,Any} with 1 entry:
@@ -202,7 +202,7 @@ using ArgParse
 * `append_arg` (non-flag): append the argument to the result. Example:
 
   ```
-  julia> @add_arg_table(settings, "-x", action => :append_arg);
+  julia> @add_arg_table!(settings, "-x", action => :append_arg);
 
   julia> parse_args(["-x", "1", "-x", "2"], settings)
   Dict{String,Any} with 1 entry:
@@ -212,7 +212,7 @@ using ArgParse
   The result will be a `Vector{Vector}` if `nargs` is a non-zero number, or one of `'*'`, `'+'`, `'R'`:
 
   ```
-  julia> @add_arg_table(settings, "-x", action => :append_arg, nargs => '*');
+  julia> @add_arg_table!(settings, "-x", action => :append_arg, nargs => '*');
 
   julia> parse_args(["-x", "1", "2", "-x", "3"], settings)
   Dict{String,Any} with 1 entry:
@@ -222,7 +222,7 @@ using ArgParse
 * `append_const` (flag): append the value passed as `constant` in the entry settings. Example:
 
   ```
-  julia> @add_arg_table(settings, "-x", action => :append_const, constant => 1);
+  julia> @add_arg_table!(settings, "-x", action => :append_const, constant => 1);
 
   julia> parse_args(["-x", "-x", "-x"], settings)
   Dict{String,Any} with 1 entry:
@@ -233,7 +233,7 @@ using ArgParse
   invoked. Example:
 
   ```
-  julia> @add_arg_table(settings, "-x", action => :count_invocations);
+  julia> @add_arg_table!(settings, "-x", action => :count_invocations);
 
   julia> parse_args(["-x", "-x", "-x"], settings)
   Dict{String,Any} with 1 entry:
@@ -244,7 +244,7 @@ using ArgParse
   `false`. Example:
 
   ```
-  julia> @add_arg_table(settings, "-x", action => :show_help);
+  julia> @add_arg_table!(settings, "-x", action => :show_help);
 
   julia> parse_args(["-x"], settings)
   usage: <PROGRAM> [-x]
@@ -259,7 +259,7 @@ using ArgParse
   ```
   julia> settings.version = "1.0";
 
-  julia> @add_arg_table(settings, "-x", action => :show_version);
+  julia> @add_arg_table!(settings, "-x", action => :show_version);
 
   julia> parse_args(["-v"], settings)
   1.0
@@ -285,7 +285,7 @@ using ArgParse
 function parse_commandline()
     s = ArgParseSettings()
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "cmd1", "C"
             help = "first command"
             action = :command
@@ -348,7 +348,7 @@ optional arguments:
 
 The argument settings and tables for commands can be accessed by using a dict-like notation, i.e. `settings["cmd1"]` is an
 `ArgParseSettings` object specific to the `"cmd1"` command. Therefore, to populate a command sub-argument-table, simply
-use `@add_arg_table(settings["cmd1"], table...)` and similar.
+use `@add_arg_table!(settings["cmd1"], table...)` and similar.
 
 These sub-settings are created when a command is added to the argument table, and by default they inherit their parent general
 settings except for the `prog` setting (which is auto-generated, as can be seen in the above example) and the
@@ -376,7 +376,7 @@ arguments, displayed in that order. Example:
 ```@repl args
 settings = ArgParseSettings(exit_after_help = false);
 
-@add_arg_table settings begin
+@add_arg_table! settings begin
    "--opt"
    "arg"
      required = true
@@ -395,44 +395,44 @@ options in the group can be provided. A group can also be declared to be require
 one argument in the group needs to be provided.
 
 ```@docs
-add_arg_group
+add_arg_group!
 ```
 
 ```@docs
-set_default_arg_group
+set_default_arg_group!
 ```
 
-Besides setting a default group with `add_arg_group` and `set_default_group`, it's also possible to assign individual arguments
-to a group by using the `group` setting in the argument table entry, which follows the same rules as `set_default_group`.
+Besides setting a default group with `add_arg_group!` and `set_default_group!`, it's also possible to assign individual arguments
+to a group by using the `group` setting in the argument table entry, which follows the same rules as `set_default_group!`.
 
 Note that if the `add_help` or `add_version` general settings are `true`, the `--help, -h` and `--version` options
 will always be added to the `optional` group.
 
 ## Argument table styles
 
-Here are some examples of styles for the [`@add_arg_table`](@ref) marco and [`add_arg_table`](@ref) function invocation:
+Here are some examples of styles for the [`@add_arg_table!`](@ref) marco and [`add_arg_table!`](@ref) function invocation:
 
 ```julia
-@add_arg_table settings begin
+@add_arg_table! settings begin
     "--opt", "-o"
         help = "an option"
     "arg"
         help = "a positional argument"
 end
 
-@add_arg_table(settings
+@add_arg_table!(settings
     , ["--opt", "-o"]
     ,    help => "an option"
     , "arg"
     ,    help => "a positional argument"
     )
 
-@add_arg_table settings begin
+@add_arg_table! settings begin
     (["--opt", "-o"]; help = an option)
     ("arg"; help = "a positional argument")
 end
 
-@add_arg_table(settings,
+@add_arg_table!(settings,
     ["-opt", "-o"],
     begin
         help = "an option"
@@ -442,7 +442,7 @@ end
         help = "a positional argument"
     end)
 
-add_arg_table(settings,
+add_arg_table!(settings,
     ["-opt", "-o"], Dict(:help => "an option"),
     "arg"         , Dict(:help => "a positional argument")
     )

--- a/docs/src/conflicts.md
+++ b/docs/src/conflicts.md
@@ -24,5 +24,5 @@ the resolution of most of the conflicts in favor of the newest added entry. The 
 * In case of duplicate positional arguments metavars, the older argument is deleted
 * A command can override an argument with the same destination key
 * However, an argument can never override a command; neither can a command override another command when added
-  with `@add_arg_table` (compatible commands are merged by [`import_settings`](@ref) though)
+  with `@add_arg_table!` (compatible commands are merged by [`import_settings!`](@ref) though)
 * Conflicting command aliases are removed

--- a/docs/src/import.md
+++ b/docs/src/import.md
@@ -4,7 +4,5 @@ It may be useful in some cases to import an argument table into the one which is
 specialized versions of a common interface.
 
 ```@docs
-import_settings
+import_settings!
 ```
-
-

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -17,7 +17,7 @@ as well.
 To install the module, use Julia's package manager: start pkg mode by pressing `]` and then enter:
 
 ```
-(v1.0) pkg> add ArgParse
+(v1.3) pkg> add ArgParse
 ```
 
 Dependencies will be installed automatically.
@@ -31,12 +31,12 @@ using ArgParse
 ```
 
 There are two main steps for defining a command-line interface: creating an [`ArgParseSettings`](@ref) object, and
-populating it with allowed arguments and options using either the macro [`@add_arg_table`](@ref) or the
-function [`add_arg_table`](@ref) (see the [Argument table](@ref) section):
+populating it with allowed arguments and options using either the macro [`@add_arg_table!`](@ref) or the
+function [`add_arg_table!`](@ref) (see the [Argument table](@ref) section):
 
 ```
 s = ArgParseSettings()
-@add_arg_table s begin
+@add_arg_table! s begin
     "--opt1"
         help = "an option with an argument"
     "--opt2", "-o"
@@ -85,7 +85,7 @@ using ArgParse
 function parse_commandline()
     s = ArgParseSettings()
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--opt1"
             help = "an option with an argument"
         "--opt2", "-o"
@@ -169,7 +169,7 @@ Parsed args:
 
 From these examples, a number of things can be noticed:
 
-* `opt1` defaults to `nothing`, since no `default` setting was used for it in `@add_arg_table`
+* `opt1` defaults to `nothing`, since no `default` setting was used for it in `@add_arg_table!`
 * `opt1` argument type, begin unspecified, defaults to `Any`, but in practice it's parsed as a
   string (e.g. `"2+2"`)
 * `opt2` instead has `Int` argument type, so `"4"` will be parsed and converted to an integer,

--- a/examples/argparse_example1.jl
+++ b/examples/argparse_example1.jl
@@ -7,7 +7,7 @@ function main(args)
     # initialize the settings (the description is for the help screen)
     s = ArgParseSettings(description = "Example 1 for argparse.jl: minimal usage.")
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--opt1"               # an option (will take an argument)
         "--opt2", "-o"         # another option, with short form
         "arg1"                 # a positional argument

--- a/examples/argparse_example2.jl
+++ b/examples/argparse_example2.jl
@@ -8,7 +8,7 @@ function main(args)
                          "flags, options help, " *
                          "required arguments.")
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--opt1"
             help = "an option"     # used by the help screen
         "--opt2", "-o"

--- a/examples/argparse_example3.jl
+++ b/examples/argparse_example3.jl
@@ -12,7 +12,7 @@ function main(args)
                          version = "Version 1.0", # version info
                          add_version = true)      # audo-add version option
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--opt1"
             nargs = '?'              # '?' means optional argument
             arg_type = Int           # only Int arguments allowed

--- a/examples/argparse_example4.jl
+++ b/examples/argparse_example4.jl
@@ -10,7 +10,7 @@ function main(args)
                          "dest_name, metvar, range_tested, " *
                          "alternative actions.")
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--opt1"
             action = :append_const   # appends 'constant' to 'dest_name'
             arg_type = String        # the only utility of this is restricting the dest array type

--- a/examples/argparse_example5.jl
+++ b/examples/argparse_example5.jl
@@ -8,7 +8,7 @@ function main(args)
                              # which we want to extend
 
     # So we just add a simple table
-    @add_arg_table s0 begin
+    @add_arg_table! s0 begin
         "--parent-flag", "-o"
             action=>"store_true"
             help=>"parent flag"
@@ -25,11 +25,11 @@ function main(args)
                          add_help = false,           # disable auto-add of --help option
                          version = "Version 1.0")    # we set the version info, but --version won't be added
 
-    import_settings(s, s0)       # now s has all of s0 arguments (except help/version)
+    import_settings!(s, s0)      # now s has all of s0 arguments (except help/version)
 
     s.error_on_conflict = false  # do not error-out when trying to override an option
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "-o"                       # this will partially override s0's --parent-flag
             action = :store_true
             help = "child flag"

--- a/examples/argparse_example6.jl
+++ b/examples/argparse_example6.jl
@@ -7,7 +7,7 @@ function main(args)
     s = ArgParseSettings("Example 6 for argparse.jl: " *
                          "commands and their associated sub-tables.")
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "run"
             action = :command        # adds a command which will be read from an argument
             help = "start running mode"
@@ -16,7 +16,7 @@ function main(args)
             help = "start jumping mode"
     end
 
-    @add_arg_table s["run"] begin    # add command arg_table: same as usual, but invoked on s["cmd"]
+    @add_arg_table! s["run"] begin    # add command arg_table: same as usual, but invoked on s["cmd"]
         "--speed"
             arg_type = Float64
             default = 10.
@@ -29,7 +29,7 @@ function main(args)
     s["jump"].autofix_names = true                     # this uses dashes in long options, underscores
                                                        # in auto-generated dest_names
 
-    @add_arg_table s["jump"] begin
+    @add_arg_table! s["jump"] begin
         "--higher"
             action = :store_true
             help = "enhance jumping"

--- a/examples/argparse_example7.jl
+++ b/examples/argparse_example7.jl
@@ -7,9 +7,9 @@ function main(args)
     s = ArgParseSettings("Example 7 for argparse.jl: " *
                          "argument groups.")
 
-    add_arg_group(s, "stack options") # add a group and sets it as the default
-    @add_arg_table s begin            # all options (and arguments) in this table
-                                      # will be assigned to the newly added group
+    add_arg_group!(s, "stack options") # add a group and sets it as the default
+    @add_arg_table! s begin            # all options (and arguments) in this table
+                                       # will be assigned to the newly added group
         "--opt1"
             action = :append_const
             arg_type = String
@@ -24,12 +24,12 @@ function main(args)
             help = "append O2 to the stack"
     end
 
-    add_arg_group(s, "weird options", "weird") # another group, this time with a tag which allows
-                                               # to refer to it
+    add_arg_group!(s, "weird options", "weird") # another group, this time with a tag which allows
+                                                # to refer to it
 
-    set_default_arg_group(s, "weird") # set the default group (useless here, since we just added it)
+    set_default_arg_group!(s, "weird") # set the default group (useless here, since we just added it)
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--awkward-option"
             nargs = '+'
             action = :append_arg
@@ -41,10 +41,10 @@ function main(args)
                    "stored in chunks"
     end
 
-    set_default_arg_group(s) # reset the default arg group (which means arguments
-                             # are automatically assigned to commands/options/pos.args
-                             # groups)
-    @add_arg_table s begin
+    set_default_arg_group!(s) # reset the default arg group (which means arguments
+                              # are automatically assigned to commands/options/pos.args
+                              # groups)
+    @add_arg_table! s begin
         "-k"
             action = :store_const
             default = 0

--- a/examples/argparse_example8.jl
+++ b/examples/argparse_example8.jl
@@ -7,8 +7,8 @@ function main(args)
     s = ArgParseSettings("Example 8 for argparse.jl: " *
                          "mutually exclusive and requiredd groups.")
 
-    add_arg_group(s, "Mutually exclusive options", exclusive=true)
-    @add_arg_table s begin
+    add_arg_group!(s, "Mutually exclusive options", exclusive=true)
+    @add_arg_table! s begin
         "--maybe", "-M"
             action = :store_true
             help = "maybe..."
@@ -17,8 +17,8 @@ function main(args)
             help = "maybe not..."
     end
 
-    add_arg_group(s, "Required mutually exclusive options", exclusive=true, required=true)
-    @add_arg_table s begin
+    add_arg_group!(s, "Required mutually exclusive options", exclusive=true, required=true)
+    @add_arg_table! s begin
         "--either", "-E"
             action = :store_true
             help = "choose the `either` option"
@@ -28,8 +28,8 @@ function main(args)
             help = "set the `or` option"
     end
 
-    add_arg_group(s, "Required arguments", required=true)
-    @add_arg_table s begin
+    add_arg_group!(s, "Required arguments", required=true)
+    @add_arg_table! s begin
         "--enhance", "-+"
             action = :store_const
             default = 0

--- a/src/ArgParse.jl
+++ b/src/ArgParse.jl
@@ -19,10 +19,10 @@ export
     ArgParseError,
 
 # functions & macros
-    add_arg_table,
-    @add_arg_table,
-    add_arg_group,
-    set_default_arg_group,
+    add_arg_table!,
+    @add_arg_table!,
+    add_arg_group!,
+    set_default_arg_group!,
     import_settings!,
     usage_string,
     parse_args
@@ -34,5 +34,6 @@ import Base: show, getindex, setindex!, haskey
 include("common.jl")
 include("settings.jl")
 include("parsing.jl")
+include("deprecated.jl")
 
 end # module ArgParse

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,41 @@
+
+@deprecate add_arg_table add_arg_table!
+@deprecate import_settings(settings, other) import_settings!(settings, other)
+@deprecate import_settings(settings, other, ao) import_settings!(settings, other; args_only=ao)
+@deprecate add_arg_group(args...; kw...) add_arg_group!(args...; kw...)
+@deprecate set_default_arg_group set_default_arg_group!
+
+# The Base.@deprecate macro doesn't work with macros
+# Here's an attempt at mimicking most of what that does
+# and deprecate @add_arg_table -> @add_arg_table!
+using Base: JLOptions, CoreLogging
+using Logging: @logmsg
+
+function callframe(st, name)
+    found = false
+    for sf in st
+        sf == StackTraces.UNKNOWN && continue
+        if found && sf.func == Symbol("top-level scope")
+            return sf
+        end
+        sf.func == name && (found = true)
+    end
+    return StackTraces.UNKNOWN
+end
+
+export @add_arg_table
+macro add_arg_table(s, x...)
+    opts = JLOptions()
+    msg = "`@add_arg_table` is deprecated, use `@add_arg_table!` instead"
+    opts.depwarn == 2 && throw(ErrorException(msg))
+    deplevel = opts.depwarn == 1 ? CoreLogging.Warn : CoreLogging.BelowMinLevel
+    st = stacktrace()
+    caller = callframe(st, Symbol("@add_arg_table"))
+    @logmsg(deplevel, msg,
+            _file = String(caller.file),
+            _line = caller.line,
+            _group = :depwarn,
+            maxlog = 1)
+
+    return _add_arg_table!(s, x...)
+end

--- a/test/argparse_test01.jl
+++ b/test/argparse_test01.jl
@@ -1,5 +1,5 @@
 # test 01: minimal options/arguments, auto-generated help/version;
-#          function version of add_arg_table
+#          function version of add_arg_table!
 
 @testset "test 01" begin
 
@@ -7,7 +7,7 @@ function ap_settings1()
 
     s = ArgParseSettings()
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--opt1"               # an option (will take an argument)
         "--opt2", "-o"         # another option, with short form
         "arg1"                 # a positional argument
@@ -22,7 +22,7 @@ function ap_settings1b()
 
     s = ArgParseSettings(exc_handler = ArgParse.debug_handler)
 
-    add_arg_table(s,
+    add_arg_table!(s,
         "--opt1",
         ["--opt2", "-o"],
         "arg1")
@@ -57,20 +57,20 @@ for s = [ap_settings1(), ap_settings1b()]
     @ap_test_throws ap_test1(["-o"])
     @ap_test_throws ap_test1(["--opt1"])
 
-    @ee_test_throws @add_arg_table(s, "--opt1") # long option already added
-    @ee_test_throws @add_arg_table(s, "-o") # short option already added
+    @ee_test_throws @add_arg_table!(s, "--opt1") # long option already added
+    @ee_test_throws @add_arg_table!(s, "-o") # short option already added
 end
 
 # test malformed tables
 function ap_settings1c()
 
-    @ee_test_throws @add_arg_table begin
+    @ee_test_throws @add_arg_table! begin
         "-a"
     end
 
     s = ArgParseSettings(exc_handler = ArgParse.debug_handler)
 
-    @ee_test_throws add_arg_table(s, Dict(:action => :store_true), "-a")
+    @ee_test_throws add_arg_table!(s, Dict(:action => :store_true), "-a")
     @test_addtable_failure s begin
         action = :store_true
         "-a"
@@ -78,8 +78,8 @@ function ap_settings1c()
     @test_addtable_failure s begin
         action => :store_true
     end
-    @ee_test_throws add_arg_table(s, "-a", Dict(:wat => :store_true))
-    @ee_test_throws @add_arg_table s begin
+    @ee_test_throws add_arg_table!(s, "-a", Dict(:wat => :store_true))
+    @ee_test_throws @add_arg_table! s begin
         "-a"
             wat => :store_true
     end

--- a/test/argparse_test02.jl
+++ b/test/argparse_test02.jl
@@ -1,7 +1,7 @@
 # test 02: version information, default values, flags,
 #          options with types, optional arguments, variable
 #          number of arguments;
-#          function version of add_arg_table
+#          function version of add_arg_table!
 
 @testset "test 02" begin
 
@@ -13,7 +13,7 @@ function ap_settings2()
                          add_version = true,
                          exc_handler = ArgParse.debug_handler)
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--opt1"
             nargs = '?'              # '?' means optional argument
             arg_type = Int           # only Int arguments allowed
@@ -51,7 +51,7 @@ function ap_settings2b()
                          add_version = true,
                          exc_handler = ArgParse.debug_handler)
 
-    add_arg_table(s,
+    add_arg_table!(s,
         "--opt1", Dict(
             :nargs => '?',             # '?' means optional argument
             :arg_type => Int,          # only Int arguments allowed
@@ -89,7 +89,7 @@ function ap_settings2c()
                          add_version = true,
                          exc_handler = ArgParse.debug_handler)
 
-    @add_arg_table(s
+    @add_arg_table!(s
         , "--opt1"
         ,     nargs = '?'              # '?' means optional argument
         ,     arg_type = Int           # only Int arguments allowed
@@ -127,7 +127,7 @@ function ap_settings2d()
                          add_version = true,
                          exc_handler = ArgParse.debug_handler)
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         ("--opt1";
               nargs = '?';              # '?' means optional argument
               arg_type = Int;           # only Int arguments allowed
@@ -165,7 +165,7 @@ function ap_settings2e()
                          add_version = true,
                          exc_handler = ArgParse.debug_handler)
 
-    @add_arg_table(s,
+    @add_arg_table!(s,
         "--opt1",
         begin
             nargs = '?'              # '?' means optional argument
@@ -240,12 +240,12 @@ for s = [ap_settings2(), ap_settings2b(), ap_settings2c(), ap_settings2d(), ap_s
     @ap_test_throws ap_test2(["--opt", "", "X", "Y"])
     @ap_test_throws ap_test2(["--opt", "1e-2", "X", "Y"])
 
-    @ee_test_throws @add_arg_table(s, "required_arg_after_optional_args", required = true)
+    @ee_test_throws @add_arg_table!(s, "required_arg_after_optional_args", required = true)
     # wrong default
-    @ee_test_throws @add_arg_table(s, "--opt", arg_type = Int, default = 1.5)
+    @ee_test_throws @add_arg_table!(s, "--opt", arg_type = Int, default = 1.5)
     # wrong range tester
-    @ee_test_throws @add_arg_table(s, "--opt", arg_type = Int, range_tester = x->string(x), default = 1)
-    @ee_test_throws @add_arg_table(s, "--opt", arg_type = Int, range_tester = x->sqrt(x)<1, default = -1)
+    @ee_test_throws @add_arg_table!(s, "--opt", arg_type = Int, range_tester = x->string(x), default = 1)
+    @ee_test_throws @add_arg_table!(s, "--opt", arg_type = Int, range_tester = x->sqrt(x)<1, default = -1)
 end
 
 end

--- a/test/argparse_test03.jl
+++ b/test/argparse_test03.jl
@@ -19,7 +19,7 @@ function ap_settings3()
     s = ArgParseSettings("Test 3 for ArgParse.jl",
                          exc_handler = ArgParse.debug_handler)
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--opt1"
             action = :append_const   # appends 'constant' to 'dest_name'
             arg_type = String
@@ -115,33 +115,33 @@ let s = ap_settings3()
     @ap_test_throws ap_test3(["--collect", "0.5"])
 
     # invalid option name
-    @ee_test_throws @add_arg_table(s, "-2", action = :store_true)
+    @ee_test_throws @add_arg_table!(s, "-2", action = :store_true)
     # wrong constants
-    @ee_test_throws @add_arg_table(s, "--opt", action = :store_const, arg_type = Int, default = 1, constant = 1.5)
-    @ee_test_throws @add_arg_table(s, "--opt", action = :append_const, arg_type = Int, constant = 1.5)
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :store_const, arg_type = Int, default = 1, constant = 1.5)
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :append_const, arg_type = Int, constant = 1.5)
     # wrong defaults
-    @ee_test_throws @add_arg_table(s, "--opt", action = :append_arg, arg_type = Int, default = Float64[])
-    @ee_test_throws @add_arg_table(s, "--opt", action = :append_arg, nargs = '+', arg_type = Int, default = Vector{Float64}[])
-    @ee_test_throws @add_arg_table(s, "--opt", action = :store_arg, nargs = '+', arg_type = Int, default = [1.5])
-    @ee_test_throws @add_arg_table(s, "--opt", action = :store_arg, nargs = '+', arg_type = Int, default = 1)
-    @ee_test_throws @add_arg_table(s, "--opt", action = :append_arg, arg_type = Int, range_tester=x->x<=1, default = Int[0, 1, 2])
-    @ee_test_throws @add_arg_table(s, "--opt", action = :append_arg, nargs = '+', arg_type = Int, range_tester=x->x<=1, default = Vector{Int}[[1,1],[0,2]])
-    @ee_test_throws @add_arg_table(s, "--opt", action = :store_arg, nargs = '+', range_tester = x->x<=1, default = [1.5])
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :append_arg, arg_type = Int, default = Float64[])
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :append_arg, nargs = '+', arg_type = Int, default = Vector{Float64}[])
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :store_arg, nargs = '+', arg_type = Int, default = [1.5])
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :store_arg, nargs = '+', arg_type = Int, default = 1)
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :append_arg, arg_type = Int, range_tester=x->x<=1, default = Int[0, 1, 2])
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :append_arg, nargs = '+', arg_type = Int, range_tester=x->x<=1, default = Vector{Int}[[1,1],[0,2]])
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :store_arg, nargs = '+', range_tester = x->x<=1, default = [1.5])
     # no constants
-    @ee_test_throws @add_arg_table(s, "--opt", action = :store_const, arg_type = Int, default = 1)
-    @ee_test_throws @add_arg_table(s, "--opt", action = :append_const, arg_type = Int)
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :store_const, arg_type = Int, default = 1)
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :append_const, arg_type = Int)
     # incompatible action
-    @ee_test_throws @add_arg_table(s, "--opt3", action = :store_const, arg_type = String, constant = "O3", dest_name = "O_stack", help = "append O3")
+    @ee_test_throws @add_arg_table!(s, "--opt3", action = :store_const, arg_type = String, constant = "O3", dest_name = "O_stack", help = "append O3")
     # wrong range tester
-    @ee_test_throws @add_arg_table(s, "--opt", action = :append_arg, arg_type = Int, range_tester=x->string(x), default = Int[0, 1, 2])
-    @ee_test_throws @add_arg_table(s, "--opt", action = :append_arg, nargs = '+', arg_type = Int, range_tester=x->string(x), default = Vector{Int}[[1,1],[0,2]])
-    @ee_test_throws @add_arg_table(s, "--opt", action = :store_arg, nargs = '+', range_tester = x->string(x), default = [1.5])
-    @ee_test_throws @add_arg_table(s, "--opt", action = :store_arg, nargs = '+', range_tester = x->sqrt(x)<2, default = [-1.5])
-    @ee_test_throws @add_arg_table(s, "--opt", action = :append_arg, nargs = '+', arg_type = Int, range_tester=x->sqrt(x)<2, default = Vector{Int}[[1,1],[0,-2]])
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :append_arg, arg_type = Int, range_tester=x->string(x), default = Int[0, 1, 2])
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :append_arg, nargs = '+', arg_type = Int, range_tester=x->string(x), default = Vector{Int}[[1,1],[0,2]])
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :store_arg, nargs = '+', range_tester = x->string(x), default = [1.5])
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :store_arg, nargs = '+', range_tester = x->sqrt(x)<2, default = [-1.5])
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :append_arg, nargs = '+', arg_type = Int, range_tester=x->sqrt(x)<2, default = Vector{Int}[[1,1],[0,-2]])
 
     # allow ambiguous options
     s.allow_ambiguous_opts = true
-    @add_arg_table(s, "-2", action = :store_true)
+    @add_arg_table!(s, "-2", action = :store_true)
     @test ap_test3([]) == Dict{String,Any}("O_stack"=>String[], "k"=>0, "u"=>0, "array"=>[7, 3, 2], "custom"=>CustomType(), "oddint"=>1, "collect"=>[], "awk"=>Any[Any["X"]], "2"=>false)
     @test ap_test3(["-2"]) == Dict{String,Any}("O_stack"=>String[], "k"=>0, "u"=>0, "array"=>[7, 3, 2], "custom"=>CustomType(), "oddint"=>1, "collect"=>[], "awk"=>Any[["X"]], "2"=>true)
     @test ap_test3(["--awk", "X", "-2"]) == Dict{String,Any}("O_stack"=>String[], "k"=>0, "u"=>0, "array"=>[7, 3, 2], "custom"=>CustomType(), "oddint"=>1, "collect"=>[], "awk"=>Any[Any["X"], Any["X"]], "2"=>true)

--- a/test/argparse_test04.jl
+++ b/test/argparse_test04.jl
@@ -8,7 +8,7 @@ function ap_settings4()
                              # which we want to extend
 
     # So we just add a simple table
-    @add_arg_table s0 begin
+    @add_arg_table! s0 begin
         "--parent-flag", "-o"
             action = "store_true"
             help = "parent flag"
@@ -29,7 +29,7 @@ function ap_settings4()
 
     import_settings!(s, s0)        # now s has all of s0 arguments (except help/version)
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "-o"                       # this will partially override s0's --parent-flag
             action = :store_true
             help = "child flag"
@@ -60,7 +60,7 @@ function ap_settings4b()
                           exc_handler = ArgParse.debug_handler)
 
     # So we just add a simple table
-    @add_arg_table s0 begin
+    @add_arg_table! s0 begin
         "--parent-flag", "-o"
             action = "store_true"
             help = "parent flag"
@@ -76,9 +76,9 @@ function ap_settings4b()
     s = ArgParseSettings("Test 4 for ArgParse.jl",
                          version = "Version 1.0")
 
-    import_settings!(s, s0, false)  # args_only set to false
+    import_settings!(s, s0, args_only=false)
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "-o"
             action = :store_true
             help = "child flag"
@@ -131,7 +131,7 @@ for s = [ap_settings4(), ap_settings4b()]
 
     # same metavar as another argument
     s.error_on_conflict = true
-    @ee_test_throws @add_arg_table(s, "other-arg", metavar="parent-argument")
+    @ee_test_throws @add_arg_table!(s, "other-arg", metavar="parent-argument")
 end
 
 
@@ -142,7 +142,7 @@ function ap_settings4_base()
                          version = "Version 1.0",
                          exc_handler = ArgParse.debug_handler)
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "-o"
             action = :store_true
             help = "child flag"
@@ -158,7 +158,7 @@ function ap_settings4_conflict1()
 
     s0 = ArgParseSettings()
 
-    @add_arg_table s0 begin
+    @add_arg_table! s0 begin
         "--parent-flag", "-o"
             action = "store_true"
             help = "parent flag"
@@ -171,7 +171,7 @@ function ap_settings4_conflict2()
 
     s0 = ArgParseSettings()
 
-    @add_arg_table s0 begin
+    @add_arg_table! s0 begin
         "--flag"
             action = "store_true"
             help = "another parent flag"

--- a/test/argparse_test05.jl
+++ b/test/argparse_test05.jl
@@ -8,7 +8,7 @@ function ap_settings5()
                          exc_handler = ArgParse.debug_handler,
                          exit_after_help = false)
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "run"
             action = :command
             help = "start running mode"
@@ -17,7 +17,7 @@ function ap_settings5()
             help = "start jumping mode"
     end
 
-    @add_arg_table s["run"] begin
+    @add_arg_table! s["run"] begin
         "--speed"
             arg_type = Float64
             default = 10.
@@ -28,7 +28,7 @@ function ap_settings5()
     s["jump"].commands_are_required = false
     s["jump"].autofix_names = true
 
-    @add_arg_table s["jump"] begin
+    @add_arg_table! s["jump"] begin
         "--higher"
             action = :store_true
             help = "enhance jumping"
@@ -43,7 +43,7 @@ function ap_settings5()
 
     s["jump"]["som"].description = "Somersault jump mode"
 
-    @add_arg_table s["jump"]["som"] begin
+    @add_arg_table! s["jump"]["som"] begin
         "-t"
             nargs = '?'
             arg_type = Int
@@ -136,32 +136,32 @@ let s = ap_settings5()
     @test ap_test5(["run", "--speed", "3"], as_symbols = true) == Dict{Symbol,Any}(:_COMMAND_=>:run, :run=>Dict{Symbol,Any}(:speed=>3.0))
 
     # argument after command
-    @ee_test_throws @add_arg_table(s, "arg_after_command")
+    @ee_test_throws @add_arg_table!(s, "arg_after_command")
     # same name as command
-    @ee_test_throws @add_arg_table(s, "run")
-    @ee_test_throws @add_arg_table(s["jump"], "-c")
-    @ee_test_throws @add_arg_table(s["jump"], "--somersault")
+    @ee_test_throws @add_arg_table!(s, "run")
+    @ee_test_throws @add_arg_table!(s["jump"], "-c")
+    @ee_test_throws @add_arg_table!(s["jump"], "--somersault")
     # same dest_name as command
-    @ee_test_throws @add_arg_table(s["jump"], "--som")
-    @ee_test_throws @add_arg_table(s["jump"], "-s", dest_name = "som")
+    @ee_test_throws @add_arg_table!(s["jump"], "--som")
+    @ee_test_throws @add_arg_table!(s["jump"], "-s", dest_name = "som")
     # same name as command alias
-    @ee_test_throws @add_arg_table(s, "ju")
-    @ee_test_throws @add_arg_table(s, "J")
+    @ee_test_throws @add_arg_table!(s, "ju")
+    @ee_test_throws @add_arg_table!(s, "J")
     # new command with the same name as another one
-    @ee_test_throws @add_arg_table(s, ["run", "R"], action = :command)
-    @ee_test_throws @add_arg_table(s, "jump", action = :command)
+    @ee_test_throws @add_arg_table!(s, ["run", "R"], action = :command)
+    @ee_test_throws @add_arg_table!(s, "jump", action = :command)
     # new command with the same name as another one's alias
-    @ee_test_throws @add_arg_table(s, "ju", action = :command)
-    @ee_test_throws @add_arg_table(s, "J", action = :command)
+    @ee_test_throws @add_arg_table!(s, "ju", action = :command)
+    @ee_test_throws @add_arg_table!(s, "J", action = :command)
     # new command with an alias which is the same as another command
-    @ee_test_throws @add_arg_table(s, ["fast", "run"], action = :command)
-    @ee_test_throws @add_arg_table(s, ["R", "jump"], action = :command)
+    @ee_test_throws @add_arg_table!(s, ["fast", "run"], action = :command)
+    @ee_test_throws @add_arg_table!(s, ["R", "jump"], action = :command)
     # new command with an alias which is already in use
-    @ee_test_throws @add_arg_table(s, ["R", "ju"], action = :command)
-    @ee_test_throws @add_arg_table(s, ["R", "S", "J"], action = :command)
+    @ee_test_throws @add_arg_table!(s, ["R", "ju"], action = :command)
+    @ee_test_throws @add_arg_table!(s, ["R", "S", "J"], action = :command)
 
     # alias overriding by a command name
-    @add_arg_table(s, "J", action = :command, force_override = true, help = "the J command")
+    @add_arg_table!(s, "J", action = :command, force_override = true, help = "the J command")
     @test stringhelp(s) == """
         usage: $(basename(Base.source_path())) {run|jump|J}
 
@@ -175,7 +175,7 @@ let s = ap_settings5()
         """
 
     # alias overriding by a command alias
-    @add_arg_table(s, ["S", "ju"], action = :command, force_override = true, help = "the S command")
+    @add_arg_table!(s, ["S", "ju"], action = :command, force_override = true, help = "the S command")
     @test stringhelp(s) == """
         usage: $(basename(Base.source_path())) {run|jump|J|S}
 
@@ -190,11 +190,11 @@ let s = ap_settings5()
         """
 
     # cannot override a command name
-    @ee_test_throws @add_arg_table(s, ["J", "R"], action = :command, force_override = true)
-    @ee_test_throws @add_arg_table(s, ["R", "J"], action = :command, force_override = true)
+    @ee_test_throws @add_arg_table!(s, ["J", "R"], action = :command, force_override = true)
+    @ee_test_throws @add_arg_table!(s, ["R", "J"], action = :command, force_override = true)
 
     # conflict between dest_name and a reserved Symbol
-    @add_arg_table(s, "--COMMAND", dest_name="_COMMAND_")
+    @add_arg_table!(s, "--COMMAND", dest_name="_COMMAND_")
     @ee_test_throws ap_test5(["run", "--speed", "3"], as_symbols = true)
 end
 
@@ -206,7 +206,7 @@ function ap_settings5b()
                          exc_handler = ArgParse.debug_handler,
                          exit_after_help = false)
 
-    @add_arg_table s0 begin
+    @add_arg_table! s0 begin
         "run", "R"
             action = :command
             help = "start running mode"
@@ -221,7 +221,7 @@ function ap_settings5b()
                    "perform the command"
     end
 
-    @add_arg_table s0["run"] begin
+    @add_arg_table! s0["run"] begin
         "--speed"
             arg_type = Float64
             default = 10.
@@ -233,10 +233,10 @@ function ap_settings5b()
     s0["jump"].autofix_names = true
     s0["jump"].add_help = false
 
-    add_arg_group(s0["jump"], "modifiers", "modifiers")
-    set_default_arg_group(s0["jump"])
+    add_arg_group!(s0["jump"], "modifiers", "modifiers")
+    set_default_arg_group!(s0["jump"])
 
-    @add_arg_table s0["jump"] begin
+    @add_arg_table! s0["jump"] begin
         "--higher"
             action = :store_true
             help = "enhance jumping"
@@ -250,8 +250,8 @@ function ap_settings5b()
             help = "clap feet jumping mode"
     end
 
-    add_arg_group(s0["jump"], "other")
-    @add_arg_table s0["jump"] begin
+    add_arg_group!(s0["jump"], "other")
+    @add_arg_table! s0["jump"] begin
         "--help"
             action = :show_help
             help = "show this help message " *
@@ -260,7 +260,7 @@ function ap_settings5b()
 
     s0["jump"]["som"].description = "Somersault jump mode"
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "jump", "run", "J"              # The "run" alias will be overridden
             action = :command
             help = "start jumping mode"
@@ -277,17 +277,17 @@ function ap_settings5b()
     s["jump"].autofix_names = true
     s["jump"].add_help = false
 
-    add_arg_group(s["jump"], "modifiers", "modifiers")
-    @add_arg_table s["jump"] begin
+    add_arg_group!(s["jump"], "modifiers", "modifiers")
+    @add_arg_table! s["jump"] begin
         "--lower"
             action = :store_false
             dest_name = "higher"
             help = "reduce jumping"
     end
 
-    set_default_arg_group(s["jump"])
+    set_default_arg_group!(s["jump"])
 
-    @add_arg_table s["jump"] begin
+    @add_arg_table! s["jump"] begin
         "--clap-feet"
             action = :command
             help = "clap feet jumping mode"
@@ -299,7 +299,7 @@ function ap_settings5b()
             help = "overridden"
     end
 
-    @add_arg_table s["fly"] begin
+    @add_arg_table! s["fly"] begin
         "--glade"
             action = :store_true
             help = "glade mode"
@@ -307,7 +307,7 @@ function ap_settings5b()
 
     s["jump"]["clap_feet"].add_version = true
 
-    @add_arg_table s["jump"]["clap_feet"] begin
+    @add_arg_table! s["jump"]["clap_feet"] begin
         "--whistle"
             action = :store_true
     end
@@ -366,11 +366,11 @@ let s = ap_settings5b()
 end
 
 let
-    s1 = @add_arg_table(ArgParseSettings(), "run", action = :command)
-    s2 = @add_arg_table(ArgParseSettings(), "--run", action = :store_true)
+    s1 = @add_arg_table!(ArgParseSettings(), "run", action = :command)
+    s2 = @add_arg_table!(ArgParseSettings(), "--run", action = :store_true)
     @ee_test_throws import_settings!(s1, s2)
     @ee_test_throws import_settings!(s2, s1) # this fails since error_on_conflict=true
-    s2 = @add_arg_table(ArgParseSettings(), ["R", "run"], action = :command)
+    s2 = @add_arg_table!(ArgParseSettings(), ["R", "run"], action = :command)
     @ee_test_throws import_settings!(s1, s2)
     @ee_test_throws import_settings!(s2, s1) # this fails since error_on_conflict=true
 end

--- a/test/argparse_test06.jl
+++ b/test/argparse_test06.jl
@@ -7,8 +7,8 @@ function ap_settings6()
     s = ArgParseSettings("Test 6 for ArgParse.jl",
                          exc_handler = ArgParse.debug_handler)
 
-    add_arg_group(s, "stack options")
-    @add_arg_table s begin
+    add_arg_group!(s, "stack options")
+    @add_arg_table! s begin
         "--opt1"
             action = :append_const
             arg_type = String
@@ -23,11 +23,11 @@ function ap_settings6()
             help = "append O2 to the stack"
     end
 
-    add_arg_group(s, "weird options", "weird")
+    add_arg_group!(s, "weird options", "weird")
 
-    set_default_arg_group(s, "weird")
+    set_default_arg_group!(s, "weird")
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--awkward-option"
             nargs = '+'
             action = :append_arg
@@ -39,9 +39,9 @@ function ap_settings6()
                    "stored in chunks"
     end
 
-    set_default_arg_group(s)
+    set_default_arg_group!(s)
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "-k"
             action = :store_const
             default = 0
@@ -55,9 +55,9 @@ function ap_settings6()
             group = "weird"
     end
 
-    set_default_arg_group(s, "weird")
+    set_default_arg_group!(s, "weird")
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--rest"
             nargs = 'R'
             help = "an option which will consume " *
@@ -108,9 +108,9 @@ let s = ap_settings6()
     @ap_test_throws ap_test6(["--şİł", "-1", "-2", "-3", "-4"])
 
     # invalid groups
-    @ee_test_throws add_arg_group(s, "invalid commands", "")
-    @ee_test_throws add_arg_group(s, "invalid commands", "#invalid")
-    @ee_test_throws @add_arg_table(s, "--opt", action = :store_true, group = "none")
+    @ee_test_throws add_arg_group!(s, "invalid commands", "")
+    @ee_test_throws add_arg_group!(s, "invalid commands", "#invalid")
+    @ee_test_throws @add_arg_table!(s, "--opt", action = :store_true, group = "none")
 end
 
 end

--- a/test/argparse_test07.jl
+++ b/test/argparse_test07.jl
@@ -7,7 +7,7 @@ function ap_settings7()
     s = ArgParseSettings(description = "Test 7 for ArgParse.jl\n\nTesting oxymoronic options",
                          exc_handler = ArgParse.debug_handler)
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--oxymoronic", "-x"
             required = true
             help = "a required option"
@@ -65,7 +65,7 @@ let s = ap_settings7()
     @ap_test_throws ap_test7(["--oxymoronic=A", "--opt=B"])
     @ap_test_throws ap_test7(["--opt=A, -o=B"])
     s.suppress_warnings = true
-    add_arg_table(s, "-g", Dict(:action=>:store_true, :required=>true))
+    add_arg_table!(s, "-g", Dict(:action=>:store_true, :required=>true))
     @test ap_test7(["--oxymoronic=A", "-o=B"]) == Dict{String,Any}("oxymoronic"=>"A", "opt"=>nothing, "o"=>"B", "flag"=>false, "g"=>false)
 end
 

--- a/test/argparse_test08.jl
+++ b/test/argparse_test08.jl
@@ -6,7 +6,7 @@ function ap_settings8a()
 
     s = ArgParseSettings(fromfile_prefix_chars=['@'])
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--opt1"               # an option (will take an argument)
         "--opt2", "-o"         # another option, with short form
         "arg1"                 # a positional argument
@@ -21,7 +21,7 @@ function ap_settings8b()  # unicode
 
     s = ArgParseSettings(fromfile_prefix_chars="@∘")
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--opt1"               # an option (will take an argument)
         "--opt2", "-o"         # another option, with short form
         "arg1"                 # a positional argument

--- a/test/argparse_test09.jl
+++ b/test/argparse_test09.jl
@@ -16,7 +16,7 @@ function ap_settings9()
                          preformatted_description=true,
                          exc_handler = ArgParse.debug_handler)
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--opt"
             required = true
             help = "a required option"

--- a/test/argparse_test10.jl
+++ b/test/argparse_test10.jl
@@ -1,5 +1,5 @@
 # test 10: multiple metavars
-#          function version of add_arg_table
+#          function version of add_arg_table!
 
 @testset "test 10" begin
 
@@ -11,7 +11,7 @@ function ap_settings10()
                          add_version = true,
                          exc_handler = ArgParse.debug_handler)
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "--opt1"
             nargs => 2                             # exactly 2 arguments must be specified
             arg_type => Int                        # only Int arguments allowed
@@ -49,7 +49,7 @@ function ap_settings10b()
                          add_version = true,
                          exc_handler = ArgParse.debug_handler)
 
-    add_arg_table(s,
+    add_arg_table!(s,
         "--opt1", Dict(
             :nargs => 2,                       # exactly 2 arguments
             :arg_type => Int,                  # only Int arguments allowed
@@ -89,7 +89,7 @@ function ap_settings10c(in_nargs)
                          add_version = true,
                          exc_handler = ArgParse.debug_handler)
 
-    add_arg_table(s,
+    add_arg_table!(s,
         "--opt1", Dict(
             :nargs => in_nargs,
             :arg_type => Int,
@@ -119,7 +119,7 @@ function ap_settings10d()
                          add_version = true,
                          exc_handler = ArgParse.debug_handler)
 
-    add_arg_table(s,
+    add_arg_table!(s,
         "opt1", Dict(
             :nargs => 2,
             :arg_type => Int,
@@ -167,12 +167,12 @@ for s = [ap_settings10(), ap_settings10b()]
     @ap_test_throws ap_test10(["X", "Y", "--opt1", "1"])
     @ap_test_throws ap_test10(["X", "Y", "--opt1", "a", "b"])
 
-    @ee_test_throws @add_arg_table(s, "required_arg_after_optional_args", required = true)
+    @ee_test_throws @add_arg_table!(s, "required_arg_after_optional_args", required = true)
     # wrong default
-    @ee_test_throws @add_arg_table(s, "--opt", arg_type = Int, default = 1.5)
+    @ee_test_throws @add_arg_table!(s, "--opt", arg_type = Int, default = 1.5)
     # wrong range tester
-    @ee_test_throws @add_arg_table(s, "--opt", arg_type = Int, range_tester = x->string(x), default = 1)
-    @ee_test_throws @add_arg_table(s, "--opt", arg_type = Int, range_tester = x->sqrt(x)<1, default = -1)
+    @ee_test_throws @add_arg_table!(s, "--opt", arg_type = Int, range_tester = x->string(x), default = 1)
+    @ee_test_throws @add_arg_table!(s, "--opt", arg_type = Int, range_tester = x->sqrt(x)<1, default = -1)
 end
 
 end

--- a/test/argparse_test11.jl
+++ b/test/argparse_test11.jl
@@ -4,12 +4,12 @@
 
     s = ArgParseSettings()
 
-    @add_arg_table s begin
+    @add_arg_table! s begin
         "say"
             action = :command
     end
 
-    @add_arg_table s["say"] begin
+    @add_arg_table! s["say"] begin
         "what"
             help = "a positional argument"
             required = true

--- a/test/argparse_test12.jl
+++ b/test/argparse_test12.jl
@@ -7,8 +7,8 @@ function ap_settings12()
     s = ArgParseSettings("Test 12 for ArgParse.jl",
                          exc_handler = ArgParse.debug_handler)
 
-    add_arg_group(s, "mutually exclusive options", exclusive=true)
-    @add_arg_table s begin
+    add_arg_group!(s, "mutually exclusive options", exclusive=true)
+    @add_arg_table! s begin
         "--maybe", "-M"
             action = :store_true
             help = "maybe..."
@@ -17,15 +17,15 @@ function ap_settings12()
             help = "maybe not..."
     end
 
-    add_arg_group(s, "required mutually exclusive options", "reqexc", exclusive=true, required=true)
-    @add_arg_table s begin
+    add_arg_group!(s, "required mutually exclusive options", "reqexc", exclusive=true, required=true)
+    @add_arg_table! s begin
         "--either", "-E"
             action = :store_true
             help = "choose the `either` option"
     end
 
-    add_arg_group(s, "required arguments", required=true)
-    @add_arg_table s begin
+    add_arg_group!(s, "required arguments", required=true)
+    @add_arg_table! s begin
         "--enhance", "-+"
             action = :store_true
             help = "set the enhancement option"
@@ -35,8 +35,8 @@ function ap_settings12()
                    "entries at once"
     end
 
-    set_default_arg_group(s, "reqexc")
-    @add_arg_table s begin
+    set_default_arg_group!(s, "reqexc")
+    @add_arg_table! s begin
         "--or", "-O"
             action = :store_arg
             arg_type = Int
@@ -44,8 +44,8 @@ function ap_settings12()
             help = "set the `or` option"
     end
 
-    set_default_arg_group(s)
-    @add_arg_table s begin
+    set_default_arg_group!(s)
+    @add_arg_table! s begin
         "-k"
             action = :store_const
             default = 0
@@ -116,9 +116,9 @@ let s = ap_settings12()
     @ap_test_throws ap_test12(["-MO55", "A", "A", "--or-perhaps=?"])
     @ap_test_throws ap_test12(["--enhanced", "-+MkO55", "A", "A", "--or-perhaps=?"])
     # invalid arguments in mutually exclusive groups
-    @ee_test_throws @add_arg_table(s, "arg2", action = :store_arg, group = "reqexc")
-    set_default_arg_group(s, "reqexc")
-    @ee_test_throws @add_arg_table(s, "arg2", action = :store_arg)
+    @ee_test_throws @add_arg_table!(s, "arg2", action = :store_arg, group = "reqexc")
+    set_default_arg_group!(s, "reqexc")
+    @ee_test_throws @add_arg_table!(s, "arg2", action = :store_arg)
 end
 
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -21,7 +21,7 @@ end
 
 macro test_addtable_failure(ex...)
     ex = [nothing, ex...]
-    ex = Expr(:call, :macroexpand, @__MODULE__, Expr(:quote, Expr(:macrocall, Symbol("@add_arg_table"), ex...)))
+    ex = Expr(:call, :macroexpand, @__MODULE__, Expr(:quote, Expr(:macrocall, Symbol("@add_arg_table!"), ex...)))
     quote
         @test_throws LoadError $ex
     end


### PR DESCRIPTION
The most important change is likely `@add_arg_table` → `@add_arg_table!`.
The others are `add_arg_table!`, `add_arg_group!`, `set_default_arg_group!`, while `import_settings!` was done in a previous commit.
(A major version bump seems like a good opportunity to finally fix this.)

Adds deprecation warnings for the exported ones so that existing codes shouldn't break (at least the tests don't...).
A slightly annoying side-effect is that in order to properly deprecate `@add_arg_table` we must add an explicit dependency on `Logging`.

There's also a minor change in `import_settings!` signature.
