### PR TITLE
reduce inference and optimization time (by turning it off)

### DIFF
--- a/src/ArgParse.jl
+++ b/src/ArgParse.jl
@@ -13,6 +13,10 @@ module ArgParse
 
 using TextWrap
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@compiler_options"))
+    @eval Base.Experimental.@compiler_options compile=min optimize=0 infer=false
+end
+
 export
 # types
     ArgParseSettings,


### PR DESCRIPTION
Benchmarking the script in https://carlobaldassi.github.io/ArgParse.jl/stable/#Quick-overview-and-a-simple-example-1:

Master
```
❯ hyperfine --warmup=1 'julia --project script.jl foo'
Benchmark #1: julia --project script.jl foo
  Time (mean ± σ):      3.166 s ±  0.064 s    [User: 3.386 s, System: 0.287 s]
  Range (min … max):    3.075 s …  3.238 s    10 runs
```

PR:
```
❯ hyperfine --warmup=1 'julia --project script.jl foo'
Benchmark #1: julia --project script.jl foo
  Time (mean ± σ):      1.271 s ±  0.016 s    [User: 1.524 s, System: 0.264 s]
  Range (min … max):    1.253 s …  1.294 s    10 runs
```