### PR TITLE
Add project_version macro

### DIFF
--- a/docs/src/settings.md
+++ b/docs/src/settings.md
@@ -2,4 +2,5 @@
 
 ```@docs
 ArgParseSettings
+@project_version
 ```

--- a/src/ArgParse.jl
+++ b/src/ArgParse.jl
@@ -29,7 +29,8 @@ export
     set_default_arg_group!,
     import_settings!,
     usage_string,
-    parse_args
+    parse_args,
+    @project_version
 
 import Base: show, getindex, setindex!, haskey
 

--- a/src/settings.jl
+++ b/src/settings.jl
@@ -1465,3 +1465,40 @@ function import_settings!(settings::ArgParseSettings,
     end
     return settings
 end
+
+"""
+    @project_version
+    @project_version(filename::AbstractString)
+
+Reads the version from the Project.toml file at the given filename, at compile time.
+If no filename is given, defaults to `Base.current_project()`.
+Intended for use with the [`ArgParseSettings`](@ref) constructor,
+to keep the settings version in sync with the project version.
+
+## Example
+
+```jl
+ArgParseSettings(add_version = true, version = @project_version)
+```
+"""
+macro project_version(filename::String=Base.current_project())
+    project_version(filename)
+end
+
+macro project_version(expr::Expr)
+    project_version(eval(expr))
+end
+
+function project_version(filename::AbstractString)::String
+    re = r"^version\s*=\s*\"(.*)\"\s*$"
+    for line in eachline(filename)
+        if startswith(line, "[")
+            break
+        end
+        if !occursin(re, line)
+            continue
+        end
+        return match(re, line)[1]
+    end
+    throw(ArgumentError("Could not find a version in the file at $(filename)"))
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,4 @@
+version = "1.0.0"
+
 [deps]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/argparse_test08.jl
+++ b/test/argparse_test08.jl
@@ -1,4 +1,4 @@
-# test 08: read args from file
+# test 08: read args from file, read version from project
 
 @testset "test 08" begin
 
@@ -62,5 +62,26 @@ end
 @ap_test_throws ArgParseSettings(fromfile_prefix_chars=['-'])
 @ap_test_throws ArgParseSettings(fromfile_prefix_chars=['Å'])
 @ap_test_throws ArgParseSettings(fromfile_prefix_chars=['8'])
+
+# default project version
+@test stringversion(ArgParseSettings(
+    add_version = true, 
+    version = @project_version
+)) == "1.0.0\n"
+
+# project version from filepath
+@test stringversion(ArgParseSettings(
+    add_version = true, 
+    version = @project_version "Project.toml"
+)) == "1.0.0\n"
+
+# project version from expression that returns a filepath
+@test stringversion(ArgParseSettings(
+    add_version = true, 
+    version = @project_version(joinpath(@__DIR__, "Project.toml"))
+)) == "1.0.0\n"
+
+# throws an error if the file doesn't contain a version
+@test_throws ArgumentError ArgParse.project_version("args-file1")
 
 end


### PR DESCRIPTION
This commit implements `@project_version`, a macro which reads the version number from a Project.toml file for use with the `version` argument of the `ArgParseSettings` function. This keeps the version returned by ArgParse in sync with the project's version automatically.