### PR TITLE
Fix project_version macro

### DIFF
--- a/src/settings.jl
+++ b/src/settings.jl
@@ -1468,25 +1468,22 @@ end
 
 """
     @project_version
-    @project_version(filename::AbstractString)
+    @project_version(filename::String...)
 
 Reads the version from the Project.toml file at the given filename, at compile time.
 If no filename is given, defaults to `Base.current_project()`.
+If multiple strings are given, they will be joined with `joinpath`.
 Intended for use with the [`ArgParseSettings`](@ref) constructor,
 to keep the settings version in sync with the project version.
 
 ## Example
 
-```jl
+```julia
 ArgParseSettings(add_version = true, version = @project_version)
 ```
 """
-macro project_version(filename::String=Base.current_project())
-    project_version(filename)
-end
-
-macro project_version(expr::Expr)
-    project_version(eval(expr))
+macro project_version(filename::Vararg{String})
+    project_version(isempty(filename) ? Base.current_project() : joinpath(filename...))
 end
 
 function project_version(filename::AbstractString)::String

--- a/test/argparse_test08.jl
+++ b/test/argparse_test08.jl
@@ -78,7 +78,7 @@ end
 # project version from expression that returns a filepath
 @test stringversion(ArgParseSettings(
     add_version = true, 
-    version = @project_version(joinpath(@__DIR__, "Project.toml"))
+    version = @project_version(".", "Project.toml")
 )) == "1.0.0\n"
 
 # throws an error if the file doesn't contain a version


### PR DESCRIPTION
The previous version of this code had a bug which causes an error when a module using the macro is imported and precompiled by another module. I didn't know it was possible to write code which can compile and run but can't precompile, which is why I missed it the first time. This change should fix all of that. I wanted there to be a way to pass `@__DIR__` to this macro, but it doesn't seem to be possible without the precompilation issue.

Sorry to be such a pain. I really don't like making mistakes on other people's projects.