### PR TITLE
Allow unrecognized options to be ignored

### DIFF
--- a/test/argparse_test02.jl
+++ b/test/argparse_test02.jl
@@ -262,6 +262,10 @@ for s = [ap_settings2(), ap_settings2b(), ap_settings2c(), ap_settings2d(), ap_s
     @ap_test_throws ap_test2(["--opt="])
     @ap_test_throws ap_test2(["--opt", "", "X", "Y"])
     @ap_test_throws ap_test2(["--opt", "1e-2", "X", "Y"])
+    @ap_test_throws ap_test2(["X", "Y", "-z"])
+    @ap_test_throws ap_test2(["X", "Y", "-z", "a b c"])
+    @ap_test_throws ap_test2(["X", "Y", "--zzz"])
+    @ap_test_throws ap_test2(["X", "Y", "--zzz", "a b c"])
 
     @ee_test_throws @add_arg_table!(s, "required_arg_after_optional_args", required = true)
     # wrong default

--- a/test/argparse_test03.jl
+++ b/test/argparse_test03.jl
@@ -127,6 +127,9 @@ let s = ap_settings3()
     @ap_test_throws ap_test3(["--custom", "default"])
     @ap_test_throws ap_test3(["--oddint", "0"])
     @ap_test_throws ap_test3(["--collect", "0.5"])
+    @ap_test_throws ap_test3(["--foobar"])
+    @ap_test_throws ap_test3(["--foobar", "1"])
+    @ap_test_throws ap_test3(["--foobar", "a b c", "--opt1", "--awk", "X", "X", "--opt2", "--opt2", "-k", "--coll", "5", "-u", "--array=[4]", "--custom", "custom", "--collect", "3", "--awkward-option=Y", "X", "--opt1", "--oddint", "-1"])
 
     # invalid option name
     @ee_test_throws @add_arg_table!(s, "-2", action = :store_true)

--- a/test/argparse_test13.jl
+++ b/test/argparse_test13.jl
@@ -1,0 +1,19 @@
+# test 13: setting ignore_unrecognized_opts with positional arguments is an error
+
+@testset "test 13" begin
+s = ArgParseSettings(description = "Test 13 for ArgParse.jl",
+                     epilog = "Have fun!",
+                     version = "Version 1.0",
+                     add_version = true,
+                     exc_handler = ArgParse.debug_handler,
+                     ignore_unrecognized_opts = true)
+
+@ee_test_throws @add_arg_table! s begin
+    "arg1"
+        nargs = 2                        # eats up two arguments; puts the result in a Vector
+        help = "first argument, two " *
+               "entries at once"
+        required = true
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ module ArgParseTests
 
 include("common.jl")
 
-for i = 1:12
+for i = 1:13
     try
         s_i = lpad(string(i), 2, "0")
         include("argparse_test$s_i.jl")


### PR DESCRIPTION
Adds a new member/argument `ignore_unrecognized_opts` to `ArgParseSettings`. When this is set to true (default is false, which keeps the existing behaviour), instead of throwing an error for unrecognized options, just skip them.

The use case I have that motivated this is that I want to have separate `ArgParse` instances in different places in my code (one for all the time, another just for tests), which should ignore each others options.

`ignore_unrecognized_options = true` is not compatible with positional arguments, because there might be an ambiguity about whether arguments following the unrecognized option should belong to the option or the positional argument. It's possibly some cases could be handled (I haven't thought hard about it), but it seemed simplest to just error if there are any positional arguements - someone who wants a particular case to be handled more intelligently can implement the logic!

The first commit adds some tests that errors are actually produced when an unrecognized option is passed - it might be worth cherry-picking that even if this feature is not wanted for some reason.