### PR TITLE
Schedule CI to run automatically every Sunday

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
       - master
     tags: '*'
   pull_request:
+  schedule:
+    # Run CI against `master` every Sunday
+    - cron: '* * * * 0'
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   schedule:
     # Run CI against `master` every Sunday
-    - cron: '* * * * 0'
+    - cron: '0 0 * * 0'
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}


### PR DESCRIPTION
I noticed that the CI last ran over 2 years ago. This is so old that the CI badge in the README no longer shows passing as all of the workflow logs have expired. This PR makes the CI run at least once a week.