### PR TITLE
Fix .github/workflows/ci.yml to run macos on arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,21 +21,26 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
         arch:
           - x64
-          - x86
-        exclude:
-          # Remove some configurations from the build matrix to reduce CI time.
-          # See https://github.com/marketplace/actions/setup-julia-environment
+        include:
+          - os: ubuntu-latest
+            arch: x86
+            version: '1'
+          - os: ubuntu-latest
+            arch: x86
+            version: 'nightly'
           - os: macOS-latest
-            arch: x86
+            arch: aarch64
+            version: 'nightly'
+        exclude:
           - os: windows-latest
-            arch: x86
+            arch: x64
+            version: '1.0'
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}


### PR DESCRIPTION
Also bump setup-julia action v2 -> v3.
Supersedes #149 in which the version bump was triggering an issue with MacOS running on intel ("x64 arch has been requested on a macOS runner that has an arm64 (Apple Silicon) architecture")

There are also some weird issues with julia 1.0 failing to resolve TextWrap on multiple setups, only Ubuntu x64 seems to work now (it used to be fine in previous CI workflows.). As a result, the test matrix is a mess of ad-hoc inclusions and exclusions.